### PR TITLE
Represent native token following the ERC-7528 standard

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
     push:
         branches: ["main"]
     pull_request:
-        branches: ["main"]
+        branches: ["main", "staging"]
 
 env:
     FOUNDRY_PROFILE: ci

--- a/src/modules/payment-module/PaymentModule.sol
+++ b/src/modules/payment-module/PaymentModule.sol
@@ -26,6 +26,9 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
     /// @dev Version identifier for the current implementation of the contract
     string public constant VERSION = "1.0.0";
 
+    /// @dev The address of the native token (ETH) this contract is deployed on following the ERC-7528 standard
+    address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
     /*//////////////////////////////////////////////////////////////////////////
                             NAMESPACED STORAGE LAYOUT
     //////////////////////////////////////////////////////////////////////////*/
@@ -173,7 +176,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
 
         // Checks: the asset is different than the native token if dealing with either a linear or tranched stream-based payment
         if (request.config.method != Types.Method.Transfer) {
-            if (request.config.asset == address(0)) {
+            if (request.config.asset == NATIVE_TOKEN) {
                 revert Errors.OnlyERC20StreamsAllowed();
             }
         }
@@ -345,7 +348,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
     /// @dev Pays the `id` request  by transfer
     function _payByTransfer(Types.PaymentRequest memory request) internal {
         // Check if the payment must be done in native token (ETH) or an ERC-20 token
-        if (request.config.asset == address(0)) {
+        if (request.config.asset == NATIVE_TOKEN) {
             // Checks: the payment amount matches the request value
             if (msg.value < request.config.amount) {
                 revert Errors.PaymentAmountLessThanRequestedAmount({ amount: request.config.amount });

--- a/test/integration/concrete/payment-module/create-request/createRequest.t.sol
+++ b/test/integration/concrete/payment-module/create-request/createRequest.t.sol
@@ -5,6 +5,7 @@ import { CreateRequest_Integration_Shared_Test } from "../../../shared/createReq
 import { Types } from "./../../../../../src/modules/payment-module/libraries/Types.sol";
 import { Errors } from "../../../../utils/Errors.sol";
 import { Events } from "../../../../utils/Events.sol";
+import { Constants } from "../../../../utils/Constants.sol";
 
 contract CreateRequest_Integration_Concret_Test is CreateRequest_Integration_Shared_Test {
     Types.PaymentRequest paymentRequest;
@@ -361,7 +362,7 @@ contract CreateRequest_Integration_Concret_Test is CreateRequest_Integration_Sha
             createPaymentRequestWithTranchedStream({ recurrence: Types.Recurrence.Weekly, recipient: address(space) });
 
         // Alter the payment asset by setting it to
-        paymentRequest.config.asset = address(0);
+        paymentRequest.config.asset = Constants.NATIVE_TOKEN;
 
         // Expect the call to revert with the {OnlyERC20StreamsAllowed} error
         vm.expectRevert(Errors.OnlyERC20StreamsAllowed.selector);
@@ -448,7 +449,7 @@ contract CreateRequest_Integration_Concret_Test is CreateRequest_Integration_Sha
         paymentRequest = createPaymentRequestWithLinearStream({ recipient: address(space) });
 
         // Alter the payment asset by setting it to
-        paymentRequest.config.asset = address(0);
+        paymentRequest.config.asset = Constants.NATIVE_TOKEN;
 
         // Expect the call to revert with the {OnlyERC20StreamsAllowed} error
         vm.expectRevert(Errors.OnlyERC20StreamsAllowed.selector);

--- a/test/integration/concrete/payment-module/pay-request/payRequest.t.sol
+++ b/test/integration/concrete/payment-module/pay-request/payRequest.t.sol
@@ -5,6 +5,7 @@ import { PayRequest_Integration_Shared_Test } from "../../../shared/payRequest.t
 import { Types } from "./../../../../../src/modules/payment-module/libraries/Types.sol";
 import { Events } from "../../../../utils/Events.sol";
 import { Errors } from "../../../../utils/Errors.sol";
+import { Constants } from "../../../../utils/Constants.sol";
 
 import { LockupLinear, LockupTranched } from "@sablier/v2-core/src/types/DataTypes.sol";
 
@@ -98,25 +99,19 @@ contract PayPayment_Integration_Concret_Test is PayRequest_Integration_Shared_Te
         whenPaymentAmountEqualToPaymentValue
     {
         // Create a mock payment request with a one-off ETH transfer from the Eve's space
-        Types.PaymentRequest memory paymentRequest =
-            createPaymentRequestWithOneOffTransfer({ asset: address(0), recipient: address(mockBadReceiver) });
+        Types.PaymentRequest memory paymentRequest = createPaymentRequestWithOneOffTransfer({
+            asset: Constants.NATIVE_TOKEN,
+            recipient: address(mockBadReceiver)
+        });
         executeCreatePaymentRequest({ paymentRequest: paymentRequest, user: users.eve });
 
+        // Retrieve the payment request ID
         uint256 paymentRequestId = _nextRequestId;
 
-        // Make Eve's space the caller for the next call to approve & transfer the payment request NFT to a bad receiver
-        //vm.startPrank({ msgSender: address(space) });
-
-        // Approve the {PaymentModule} to transfer the token
-        //paymentModule.approve({ to: address(paymentModule), tokenrequestId: paymentRequestId });
-
-        // Transfer the payment request to a bad receiver so we can test against `NativeTokenPaymentFailed`
-        //paymentModule.transferFrom({ from: address(space), to: address(mockBadReceiver), tokenrequestId: paymentRequestId });
-
-        // Make Bob the payer for this paymentRequest
+        // Make Bob the payer for this payment request
         vm.startPrank({ msgSender: users.bob });
 
-        // Expect the call to be reverted with the {NativeTokenPaymentFailed} error
+        // Expect the call to be reverted with the {NativeTokenPaymentFailed} error due to the bad receiver
         vm.expectRevert(Errors.NativeTokenPaymentFailed.selector);
 
         // Run the test

--- a/test/integration/shared/createRequest.t.sol
+++ b/test/integration/shared/createRequest.t.sol
@@ -5,6 +5,7 @@ import { Integration_Test } from "../Integration.t.sol";
 import { Types } from "./../../../src/modules/payment-module/libraries/Types.sol";
 import { Space } from "./../../../src/Space.sol";
 import { MockBadSpace } from "../../mocks/MockBadSpace.sol";
+import { Constants } from "../../utils/Constants.sol";
 
 abstract contract CreateRequest_Integration_Shared_Test is Integration_Test {
     mapping(uint256 paymentRequestId => Types.PaymentRequest) paymentRequests;
@@ -22,7 +23,8 @@ abstract contract CreateRequest_Integration_Shared_Test is Integration_Test {
         executeCreatePaymentRequest({ paymentRequest: paymentRequest, user: users.eve });
 
         // Create a mock payment request with a one-off ETH transfer
-        paymentRequest = createPaymentRequestWithOneOffTransfer({ asset: address(0), recipient: address(space) });
+        paymentRequest =
+            createPaymentRequestWithOneOffTransfer({ asset: Constants.NATIVE_TOKEN, recipient: address(space) });
         paymentRequests[2] = paymentRequest;
         executeCreatePaymentRequest({ paymentRequest: paymentRequest, user: users.eve });
 

--- a/test/mocks/MockBadSpace.sol
+++ b/test/mocks/MockBadSpace.sol
@@ -32,6 +32,9 @@ contract MockBadSpace is ISpace, AccountCore, ERC1271, ModuleManager {
 
     bytes32 private constant MSG_TYPEHASH = keccak256("AccountMessage(bytes message)");
 
+    /// @dev The address of the native token (ETH) this contract is deployed on following the ERC-7528 standard
+    address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
     /*//////////////////////////////////////////////////////////////////////////
                                     CONSTRUCTOR
     //////////////////////////////////////////////////////////////////////////*/
@@ -178,7 +181,7 @@ contract MockBadSpace is ISpace, AccountCore, ERC1271, ModuleManager {
         if (!success) revert Errors.NativeWithdrawFailed();
 
         // Log the successful native token withdrawal
-        emit AssetWithdrawn({ to: to, asset: address(0), amount: amount });
+        emit AssetWithdrawn({ to: to, asset: NATIVE_TOKEN, amount: amount });
     }
 
     /// @inheritdoc IModuleManager

--- a/test/utils/Constants.sol
+++ b/test/utils/Constants.sol
@@ -4,4 +4,7 @@ pragma solidity ^0.8.22;
 library Constants {
     /// @dev Role identifier for addresses with the default admin role
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+
+    /// @dev The address of the native token (ETH) this contract is deployed on following the ERC-7528 standard
+    address public constant NATIVE_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 }


### PR DESCRIPTION
### Changelog
- Refactored `PaymentModule.sol` to use the[ ERC-7528](https://eips.ethereum.org/EIPS/eip-7578) representation of the native token as `0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE` rather than relying on the zero-address;
- Updated tests & mocks to match the new native token implementation;

