### PR TITLE
build: fix stack too deep due to enabled optimizer

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,8 +3,6 @@ src = "src"
 out = "out"
 script = "script"
 test = "test"
-optimizer = true
-optimizer_runs = 1000
 gas_reports = ["ModuleKeeper", "DockRegistry", "Container"]
 ast = true
 build_info = true
@@ -16,6 +14,8 @@ runs = 10_000
 
 [profile.optimized]
 out = "out-optimized"
+optimizer = true
+optimizer_runs = 1000
 via_ir = true
 
 [fmt]


### PR DESCRIPTION
### Changelog:
This PR fixes the `stack too deep` error on `forge build`. It looks like the error arise when the `via_ir` is disabled and `optimizer` is set to true in the `foundry.toml` config file.

The issue has been raised [here](https://github.com/foundry-rs/foundry/issues/9674#issuecomment-2587886550).

