### PR TITLE
Fix `cancelRequest` method vulnerability

### DIFF
--- a/src/modules/payment-module/libraries/Types.sol
+++ b/src/modules/payment-module/libraries/Types.sol
@@ -47,7 +47,7 @@ library Types {
     /// @notice Enum representing the different statuses a payment request can have
     /// @custom:value Pending Payment request waiting to be accepted by the payer
     /// @custom:value Accepted Payment request has been accepted and is being paid; if the payment method is a One-Off Transfer,
-    /// the payment request status will automatically be set to `Completed`. Otherwise, it will remain `Accepted` until it is fully paid
+    /// the payment request status will automatically be set to `Paid`. Otherwise, it will remain `Accepted` until it is fully paid
     /// @custom:value Paid Payment request has been fully paid
     /// @custom:value Canceled Payment request canceled by declined by the recipient (if Transfer-based) or stream sender
     enum Status {

--- a/test/integration/concrete/payment-module/cancel-request/cancelRequest.t.sol
+++ b/test/integration/concrete/payment-module/cancel-request/cancelRequest.t.sol
@@ -33,7 +33,7 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         paymentModule.cancelRequest({ requestId: paymentRequestId });
     }
 
-    function test_RevertWhen_RequestCanceled() external whenRequestNotAlreadyPaid {
+    function test_RevertWhen_RequestCanceled() external whenRequestNotAlreadyPaid whenRequestAlreadyCanceled {
         // Set the one-off ETH transfer payment request as current one
         uint256 paymentRequestId = 2;
 
@@ -50,11 +50,41 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         paymentModule.cancelRequest({ requestId: paymentRequestId });
     }
 
-    function test_RevertWhen_PaymentMethodTransfer_SenderNotPaymentRecipient()
+    function test_RevertWhen_PaymentMethodTransfer_StatusAccepted_SenderNotPaymentRecipient()
         external
         whenRequestNotAlreadyPaid
         whenRequestNotCanceled
         givenPaymentMethodTransfer
+        givenRequestStatusAccepted
+    {
+        // Set the recurring USDT transfer-based payment request as current one
+        uint256 paymentRequestId = 3;
+
+        // Make Bob the caller who IS NOT the recipient of the payment request
+        vm.startPrank({ msgSender: users.bob });
+
+        // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
+        usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
+
+        // Pay the payment request first (status will be updated to `Accepted`)
+        paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
+            requestId: paymentRequestId
+        });
+
+        // Try to cancel the payment request as Bob
+        // Expect the call to revert with the {OnlyRequestRecipient} error
+        vm.expectRevert(Errors.OnlyRequestRecipient.selector);
+
+        // Run the test
+        paymentModule.cancelRequest({ requestId: paymentRequestId });
+    }
+
+    function test_RevertWhen_PaymentMethodTransfer_StatusPending_SenderNotPaymentRecipient()
+        external
+        whenRequestNotAlreadyPaid
+        whenRequestNotCanceled
+        givenPaymentMethodTransfer
+        givenRequestStatusPending
     {
         // Set the one-off ETH transfer payment request as current one
         uint256 paymentRequestId = 2;
@@ -256,7 +286,7 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Canceled));
     }
 
-    function test_RevertWhen_PaymentMethodTranchedStream_StatusPending_SenderNoInitialtStreamSender()
+    function test_RevertWhen_PaymentMethodTranchedStream_StatusPending_SenderNoInitialStreamSender()
         external
         whenRequestNotAlreadyPaid
         whenRequestNotCanceled

--- a/test/integration/concrete/payment-module/cancel-request/cancelRequest.tree
+++ b/test/integration/concrete/payment-module/cancel-request/cancelRequest.tree
@@ -6,11 +6,15 @@ cancelRequest.t.sol
     │   └── it should revert with the {RequestCanceled} error
     └── when the request status IS NOT Canceled
         ├── given the payment method is transfer
-        │   ├── when the sender IS NOT the request recipient
-        │   │   └── it should revert with the {OnlyRequestRecipient}
-        │   └── when the sender IS the request recipient
-        │        ├── it should mark the request as Canceled
-        │        └── it should emit a {RequestCanceled} event
+        │   ├── given the request status is Accepted
+        │   │   ├── when the sender IS NOT the request recipient
+        │   │   │   └── it should revert with the {OnlyRequestRecipient}        
+        │   └── given the request status is Pending
+        │        ├── when the sender IS NOT the request recipient
+        │        │   └── it should revert with the {OnlyRequestRecipient}
+        │        └── when the sender IS the request recipient
+        │             ├── it should mark the request as Canceled
+        │             └── it should emit a {RequestCanceled} event
         ├── given the payment method is linear stream-based
         │   ├── given the request status is Pending
         │   │   ├── when the sender IS NOT the request recipient

--- a/test/integration/shared/cancelRequest.t.sol
+++ b/test/integration/shared/cancelRequest.t.sol
@@ -20,4 +20,12 @@ abstract contract CancelRequest_Integration_Shared_Test is Integration_Test, Pay
     modifier whenSenderInitialStreamSender() {
         _;
     }
+
+    modifier whenRequestAlreadyCanceled() {
+        _;
+    }
+
+    modifier givenRequestStatusAccepted() {
+        _;
+    }
 }


### PR DESCRIPTION
### Changelog:
- Fixed a vulnerability that could be exploited in the `cancelRequest` method. When a recurring transfer-based request was in the `Accepted` state, anyone could cancel it, even though this ability should be reserved only for the payment request recipient (creator);
- Added new test case scenario to the BTT tree to validate the vulnerability fix;