### PR TITLE
Rename `Accepted` status to `Ongoing`

### DIFF
--- a/src/modules/payment-module/PaymentModule.sol
+++ b/src/modules/payment-module/PaymentModule.sol
@@ -246,7 +246,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
 
         // Handle the payment workflow depending on the payment method type
         if (request.config.method == Types.Method.Transfer) {
-            // Effects: pay the request and update its status to `Paid` or `Accepted` depending on the payment type
+            // Effects: pay the request and update its status to `Paid` or `Ongoing` depending on the payment type
             _payByTransfer(request);
         } else {
             uint256 streamId;
@@ -450,7 +450,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
                 // Check if the payment request is canceled or paid
                 streamedAmount < request.config.amount ? Types.Status.Canceled : Types.Status.Paid;
             } else {
-                return Types.Status.Accepted;
+                return Types.Status.Ongoing;
             }
         }
 
@@ -461,6 +461,6 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
             return Types.Status.Paid;
         }
 
-        return Types.Status.Accepted;
+        return Types.Status.Ongoing;
     }
 }

--- a/src/modules/payment-module/libraries/Types.sol
+++ b/src/modules/payment-module/libraries/Types.sol
@@ -46,13 +46,13 @@ library Types {
 
     /// @notice Enum representing the different statuses a payment request can have
     /// @custom:value Pending Payment request waiting to be accepted by the payer
-    /// @custom:value Accepted Payment request has been accepted and is being paid; if the payment method is a One-Off Transfer,
-    /// the payment request status will automatically be set to `Completed`. Otherwise, it will remain `Accepted` until it is fully paid
+    /// @custom:value Ongoing Payment request has been accepted and is being paid; if the payment method is a One-Off Transfer,
+    /// the payment request status will automatically be set to `Completed`. Otherwise, it will remain `Ongoing` until it is fully paid
     /// @custom:value Paid Payment request has been fully paid
     /// @custom:value Canceled Payment request canceled by declined by the recipient (if Transfer-based) or stream sender
     enum Status {
         Pending,
-        Accepted,
+        Ongoing,
         Paid,
         Canceled
     }

--- a/test/integration/concrete/payment-module/cancel-request/cancelRequest.t.sol
+++ b/test/integration/concrete/payment-module/cancel-request/cancelRequest.t.sol
@@ -150,14 +150,14 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         // Set the current payment request as a linear stream-based one
         uint256 paymentRequestId = 5;
 
-        // The payment request must be paid for its status to be updated to `Accepted`
+        // The payment request must be paid for its status to be updated to `Ongoing`
         // Make Bob the payer of the payment request (also Bob will be the stream sender)
         vm.startPrank({ msgSender: users.bob });
 
         // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
         usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
 
-        // Pay the payment request first (status will be updated to `Accepted`)
+        // Pay the payment request first (status will be updated to `Ongoing`)
         paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
             requestId: paymentRequestId
         });
@@ -183,14 +183,14 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         // Set the current payment request as a linear stream-based one
         uint256 paymentRequestId = 5;
 
-        // The payment request must be paid for its status to be updated to `Accepted`
+        // The payment request must be paid for its status to be updated to `Ongoing`
         // Make Bob the payer of the payment request (also Bob will be the initial stream sender)
         vm.startPrank({ msgSender: users.bob });
 
         // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
         usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
 
-        // Pay the payment request first (status will be updated to `Accepted`)
+        // Pay the payment request first (status will be updated to `Ongoing`)
         paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
             requestId: paymentRequestId
         });
@@ -266,14 +266,14 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         // Set the current payment request as a tranched stream-based one
         uint256 paymentRequestId = 5;
 
-        // The payment request must be paid for its status to be updated to `Accepted`
+        // The payment request must be paid for its status to be updated to `Ongoing`
         // Make Bob the payer of the payment request (also Bob will be the stream sender)
         vm.startPrank({ msgSender: users.bob });
 
         // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
         usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
 
-        // Pay the payment request first (status will be updated to `Accepted`)
+        // Pay the payment request first (status will be updated to `Ongoing`)
         paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
             requestId: paymentRequestId
         });
@@ -299,14 +299,14 @@ contract CancelRequest_Integration_Concret_Test is CancelRequest_Integration_Sha
         // Set the current payment request as a tranched stream-based one
         uint256 paymentRequestId = 5;
 
-        // The payment request must be paid for its status to be updated to `Accepted`
+        // The payment request must be paid for its status to be updated to `Ongoing`
         // Make Bob the payer of the payment request (also Bob will be the initial stream sender)
         vm.startPrank({ msgSender: users.bob });
 
         // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
         usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
 
-        // Pay the payment request first (status will be updated to `Accepted`)
+        // Pay the payment request first (status will be updated to `Ongoing`)
         paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
             requestId: paymentRequestId
         });

--- a/test/integration/concrete/payment-module/cancel-request/cancelRequest.tree
+++ b/test/integration/concrete/payment-module/cancel-request/cancelRequest.tree
@@ -18,7 +18,7 @@ cancelRequest.t.sol
         │   │   └── when the sender IS the request recipient
         │   │       ├── it should mark the request as Canceled
         │   │       └── it should emit an {RequestCanceled} event
-        │   └── given the request status is Accepted
+        │   └── given the request status is Ongoing
         │        ├── when the sender IS NOT the initial stream sender
         │        │   └── it should revert with the {OnlyInitialStreamSender} error 
         │        └── when the sender IS the initial stream sender 
@@ -31,7 +31,7 @@ cancelRequest.t.sol
             │   └── when the sender IS the request recipient
             │       ├── it should mark the request as Canceled
             │       └── it should emit an {RequestCanceled} event
-            └── given the request status is Accepted
+            └── given the request status is Ongoing
                 ├── when the sender IS NOT the initial stream sender
                 │   └──it should revert with the {OnlyInitialStreamSender} error 
                 └── when the sender IS the initial stream sender 

--- a/test/integration/concrete/payment-module/pay-request/payRequest.t.sol
+++ b/test/integration/concrete/payment-module/pay-request/payRequest.t.sol
@@ -216,7 +216,7 @@ contract PayPayment_Integration_Concret_Test is PayRequest_Integration_Shared_Te
         Types.PaymentRequest memory paymentRequest = paymentModule.getRequest({ requestId: paymentRequestId });
         Types.Status paymentRequestStatus = paymentModule.statusOf({ requestId: paymentRequestId });
 
-        assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Accepted));
+        assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Ongoing));
         assertEq(paymentRequest.config.paymentsLeft, 3);
 
         // Assert the balances of payer and recipient
@@ -268,7 +268,7 @@ contract PayPayment_Integration_Concret_Test is PayRequest_Integration_Shared_Te
         Types.PaymentRequest memory paymentRequest = paymentModule.getRequest({ requestId: paymentRequestId });
         Types.Status paymentRequestStatus = paymentModule.statusOf({ requestId: paymentRequestId });
 
-        assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Accepted));
+        assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Ongoing));
         assertEq(paymentRequest.config.streamId, 1);
         assertEq(paymentRequest.config.paymentsLeft, 0);
 
@@ -323,7 +323,7 @@ contract PayPayment_Integration_Concret_Test is PayRequest_Integration_Shared_Te
         Types.PaymentRequest memory paymentRequest = paymentModule.getRequest({ requestId: paymentRequestId });
         Types.Status paymentRequestStatus = paymentModule.statusOf({ requestId: paymentRequestId });
 
-        assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Accepted));
+        assertEq(uint8(paymentRequestStatus), uint8(Types.Status.Ongoing));
         assertEq(paymentRequest.config.streamId, 1);
         assertEq(paymentRequest.config.paymentsLeft, 0);
 

--- a/test/integration/concrete/payment-module/withdraw-request-stream/withdrawRequestStream.t.sol
+++ b/test/integration/concrete/payment-module/withdraw-request-stream/withdrawRequestStream.t.sol
@@ -14,14 +14,14 @@ contract WithdrawRequestStream_Integration_Concret_Test is WithdrawLinearStream_
         uint256 paymentRequestId = 4;
         uint256 streamId = 1;
 
-        // The payment request must be paid in order to update its status to `Accepted`
+        // The payment request must be paid in order to update its status to `Ongoing`
         // Make Bob the payer of the payment request (also Bob will be the initial stream sender)
         vm.startPrank({ msgSender: users.bob });
 
         // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
         usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
 
-        // Pay the payment request first (status will be updated to `Accepted`)
+        // Pay the payment request first (status will be updated to `Ongoing`)
         paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
             requestId: paymentRequestId
         });
@@ -51,14 +51,14 @@ contract WithdrawRequestStream_Integration_Concret_Test is WithdrawLinearStream_
         uint256 paymentRequestId = 5;
         uint256 streamId = 1;
 
-        // The payment request must be paid for its status to be updated to `Accepted`
+        // The payment request must be paid for its status to be updated to `Ongoing`
         // Make Bob the payer of the payment request (also Bob will be the initial stream sender)
         vm.startPrank({ msgSender: users.bob });
 
         // Approve the {PaymentModule} to transfer the USDT tokens on Bob's behalf
         usdt.approve({ spender: address(paymentModule), amount: paymentRequests[paymentRequestId].config.amount });
 
-        // Pay the payment request first (status will be updated to `Accepted`)
+        // Pay the payment request first (status will be updated to `Ongoing`)
         paymentModule.payRequest{ value: paymentRequests[paymentRequestId].config.amount }({
             requestId: paymentRequestId
         });

--- a/test/integration/fuzz/payRequest.t.sol
+++ b/test/integration/fuzz/payRequest.t.sol
@@ -90,7 +90,7 @@ contract PayRequest_Integration_Fuzz_Test is PayRequest_Integration_Shared_Test 
         uint40 expectedNumberOfPaymentsLeft = expectedNumberOfPayments > 0 ? expectedNumberOfPayments - 1 : 0;
 
         Types.Status expectedRequestStatus = expectedNumberOfPaymentsLeft == 0
-            && paymentRequest.config.method == Types.Method.Transfer ? Types.Status.Paid : Types.Status.Accepted;
+            && paymentRequest.config.method == Types.Method.Transfer ? Types.Status.Paid : Types.Status.Ongoing;
 
         // Expect the {RequestPaid} event to be emitted
         vm.expectEmit();


### PR DESCRIPTION
### Changelog
- Renamed the payment request status from `Accepted` to `Ongoing` to better align with off-chain components such as front ends. The term `Accepted` could have been confusing for end users, as it did not clearly indicate that they were dealing with a recurring payment that had started but was not yet fully paid. 
- Updated tests to reflect the new naming convention;