### PR TITLE
Implement `CompensationModule` v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@openzeppelin/contracts-upgradeable": "^5.1.0",
     "@openzeppelin/foundry-upgrades": "^0.3.7",
     "@prb/math": "^4.1.0",
+    "@sablier/flow": "^1.1.1",
     "@sablier/v2-core": "^1.2.0",
     "@thirdweb-dev/contracts": "^3.15.0"
   }

--- a/remappings.txt
+++ b/remappings.txt
@@ -3,6 +3,7 @@
 @openzeppelin/foundry-upgrades/=node_modules/@openzeppelin/foundry-upgrades/
 solidity-stringutils/=node_modules/@openzeppelin/foundry-upgrades/lib/solidity-stringutils/
 @sablier/v2-core/=node_modules/@sablier/v2-core/
+@sablier/flow/=node_modules/@sablier/flow/
 @prb/math/=node_modules/@prb/math/
 @thirdweb/contracts/=node_modules/@thirdweb-dev/contracts/
 @ensdomains/ens-contracts/=node_modules/@ensdomains/ens-contracts/

--- a/src/modules/compensation-module/CompensationModule.sol
+++ b/src/modules/compensation-module/CompensationModule.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import { ICompensationModule } from "./interfaces/ICompensationModule.sol";
+import { Types } from "./libraries/Types.sol";
+import { FlowStreamManager } from "./sablier-flow/FlowStreamManager.sol";
+import { ISablierFlow } from "@sablier/flow/src/interfaces/ISablierFlow.sol";
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
+
+/// @title CompensationModule
+/// @notice See the documentation in {ICompensationModule}
+contract CompensationModule is ICompensationModule, FlowStreamManager, UUPSUpgradeable {
+    /*//////////////////////////////////////////////////////////////////////////
+                            NAMESPACED STORAGE LAYOUT
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @custom:storage-location erc7201:werk.storage.CompensationModule
+    struct CompensationModuleStorage {
+        /// @notice Compensation details mapped by the `id` compensation ID
+        mapping(uint256 id => Types.Compensation) compensations;
+        /// @notice Counter to keep track of the next ID used to create a new compensation
+        uint256 nextCompensationId;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("werk.storage.CompensationModule")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant COMPENSATION_MODULE_STORAGE_LOCATION =
+        0x267484be310ddc11d8a2bbbf514e29e1cab2b3d768542b45e869f920f4b7a300;
+
+    /// @dev Retrieves the storage of the {CompensationModule} contract
+    function _getCompensationModuleStorage() internal pure returns (CompensationModuleStorage storage $) {
+        assembly {
+            $.slot := COMPENSATION_MODULE_STORAGE_LOCATION
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                    CONSTRUCTOR
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Deploys and locks the implementation contract
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @dev Initializes the proxy and the {Ownable} contract
+    function initialize(
+        ISablierFlow _sablierFlow,
+        address _initialOwner,
+        address _brokerAccount,
+        UD60x18 _brokerFee
+    )
+        public
+        initializer
+    {
+        __FlowStreamManager_init(_sablierFlow, _initialOwner, _brokerAccount, _brokerFee);
+        __UUPSUpgradeable_init();
+
+        // Retrieve the contract storage
+        CompensationModuleStorage storage $ = _getCompensationModuleStorage();
+
+        // Start the first compensation request ID from 1
+        $.nextCompensationId = 1;
+    }
+
+    /// @dev Allows only the owner to upgrade the contract
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner { }
+}

--- a/src/modules/compensation-module/interfaces/ICompensationModule.sol
+++ b/src/modules/compensation-module/interfaces/ICompensationModule.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+/// @title ICompensationModule
+/// @notice Contract module that provides functionalities to issue on-chain compensation requests
+interface ICompensationModule { }

--- a/src/modules/compensation-module/libraries/Types.sol
+++ b/src/modules/compensation-module/libraries/Types.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+/// @notice Namespace for the structs used across the {CompensationModule} related contracts
+library Types { }

--- a/src/modules/compensation-module/sablier-flow/FlowStreamManager.sol
+++ b/src/modules/compensation-module/sablier-flow/FlowStreamManager.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { Initializable } from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import { OwnableUpgradeable } from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import { ISablierFlow } from "@sablier/flow/src/interfaces/ISablierFlow.sol";
+import { Broker } from "@sablier/flow/src/types/DataTypes.sol";
+import { UD60x18 } from "@prb/math/src/UD60x18.sol";
+import { IFlowStreamManager } from "./interfaces/IFlowStreamManager.sol";
+
+/// @title FlowStreamManager
+/// @notice See the documentation in {IFlowStreamManager}
+contract FlowStreamManager is IFlowStreamManager, Initializable, OwnableUpgradeable {
+    /*//////////////////////////////////////////////////////////////////////////
+                            NAMESPACED STORAGE LAYOUT
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @custom:storage-location erc7201:werk.storage.FlowStreamManager
+    struct FlowStreamManagerStorage {
+        /// @notice The Sablier Flow contract address
+        ISablierFlow SABLIER_FLOW;
+        /// @notice Stores the initial address of the account that started the stream
+        /// By default, each stream will be created by this contract (the sender address of each stream will be address(this))
+        /// therefore this mapping is used to allow only authorized senders to execute management-related actions i.e. cancellations
+        mapping(uint256 streamId => address initialSender) initialStreamSender;
+        /// @notice The broker parameters charged to create Sablier Flow streams
+        Broker broker;
+    }
+
+    // keccak256(abi.encode(uint256(keccak256("werk.storage.FlowStreamManager")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant FLOW_STREAM_MANAGER_STORAGE_LOCATION =
+        0x4d23eed36b31d0039e60f79007ec7a6b2c9226ee2c97b0667e422be6211dfa00;
+
+    /// @dev Retrieves the storage of the {FlowStreamManager} contract
+    function _getFlowStreamManagerStorage() internal pure returns (FlowStreamManagerStorage storage $) {
+        assembly {
+            $.slot := FLOW_STREAM_MANAGER_STORAGE_LOCATION
+        }
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                            CONSTRUCTOR & INITIALIZER
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev  Deploys and locks the implementation contract
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    function __FlowStreamManager_init(
+        ISablierFlow _sablierFlow,
+        address _initialAdmin,
+        address _brokerAccount,
+        UD60x18 _brokerFee
+    )
+        internal
+        onlyInitializing
+    {
+        __Ownable_init(_initialAdmin);
+
+        // Retrieve the storage of the {FlowStreamManager} contract
+        FlowStreamManagerStorage storage $ = _getFlowStreamManagerStorage();
+
+        // Set the Sablier Flow contract address
+        $.SABLIER_FLOW = _sablierFlow;
+
+        // Set the broker account and fee
+        $.broker = Broker({ account: _brokerAccount, fee: _brokerFee });
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @inheritdoc IFlowStreamManager
+    function SABLIER_FLOW() public view override returns (ISablierFlow) {
+        return _getFlowStreamManagerStorage().SABLIER_FLOW;
+    }
+}

--- a/src/modules/compensation-module/sablier-flow/interfaces/IFlowStreamManager.sol
+++ b/src/modules/compensation-module/sablier-flow/interfaces/IFlowStreamManager.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.26;
+
+import { ISablierFlow } from "@sablier/flow/src/interfaces/ISablierFlow.sol";
+
+/// @title IFlowStreamManager
+/// @notice Contract used to create and manage Sablier Flow compatible streams
+/// @dev This code is referenced in the Sablier Flow docs: https://docs.sablier.com/guides/flow/overview
+interface IFlowStreamManager {
+    /*//////////////////////////////////////////////////////////////////////////
+                                 CONSTANT FUNCTIONS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @notice The address of the {SablierFlow} contract used to create compensation streams
+    /// @dev This is initialized at construction time and it might be different depending on the deployment chain
+    /// See https://docs.sablier.com/guides/flow/deployments
+    function SABLIER_FLOW() external view returns (ISablierFlow);
+}


### PR DESCRIPTION
## Changelog:

This PR aims to add the first version (v1) of the `CompensationModule`.

## Context:

In contrast to the `PaymentModule`, where an employee or contractor creates a payment request that must be approved and paid by the employer, the `CompensationModule` introduces a new paradigm that allows employers (companies or business owners) to create and stream compensation packages directly to their employees.
A compensation package can be composed by multiple sub-packages such as base salary, token ESOP or other bonuses. 

The current implementation is based on [Sablier Flow ](https://github.com/sablier-labs/flow/) allowing for _an undefined_ number of open-ended streams to be added to a compensation package. 