### PR TITLE
refactor(stream-manager): make Sablier methods internal

### DIFF
--- a/src/modules/payment-module/PaymentModule.sol
+++ b/src/modules/payment-module/PaymentModule.sol
@@ -331,7 +331,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
         // - A linear or tranched stream MUST be canceled by calling the `cancel` method on the according
         // {ISablierV2Lockup} contract
         else {
-            cancelStream({ streamType: request.config.method, streamId: request.config.streamId });
+            _cancelStream({ streamType: request.config.method, streamId: request.config.streamId });
         }
 
         // Effects: mark the payment request as canceled
@@ -350,7 +350,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
         Types.PaymentRequest memory request = $.requests[requestId];
 
         // Check, Effects, Interactions: withdraw from the stream
-        withdrawnAmount = withdrawMaxStream({
+        withdrawnAmount = _withdrawStream({
             streamType: request.config.method,
             streamId: request.config.streamId,
             to: request.recipient
@@ -388,7 +388,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
 
     /// @dev Create the linear stream payment
     function _payByLinearStream(Types.PaymentRequest memory request) internal returns (uint256 streamId) {
-        streamId = createLinearStream({
+        streamId = _createLinearStream({
             asset: IERC20(request.config.asset),
             totalAmount: request.config.amount,
             startTime: request.startTime,
@@ -402,7 +402,7 @@ contract PaymentModule is IPaymentModule, StreamManager, UUPSUpgradeable {
         uint40 numberOfTranches =
             Helpers.computeNumberOfPayments(request.config.recurrence, request.endTime - request.startTime);
 
-        streamId = createTranchedStream({
+        streamId = _createTranchedStream({
             asset: IERC20(request.config.asset),
             totalAmount: request.config.amount,
             startTime: request.startTime,

--- a/src/modules/payment-module/sablier-v2/interfaces/IStreamManager.sol
+++ b/src/modules/payment-module/sablier-v2/interfaces/IStreamManager.sol
@@ -78,40 +78,6 @@ interface IStreamManager {
                                 NON-CONSTANT FUNCTIONS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @notice Creates a Lockup Linear stream; See https://docs.sablier.com/concepts/protocol/stream-types#lockup-linear
-    /// @param asset The address of the ERC-20 token to be streamed
-    /// @param totalAmount The total amount of ERC-20 tokens to be streamed
-    /// @param startTime The timestamp when the stream takes effect
-    /// @param endTime The timestamp by which the stream must be paid
-    /// @param recipient The address receiving the ERC-20 tokens
-    function createLinearStream(
-        IERC20 asset,
-        uint128 totalAmount,
-        uint40 startTime,
-        uint40 endTime,
-        address recipient
-    )
-        external
-        returns (uint256 streamId);
-
-    /// @notice Creates a Lockup Tranched stream; See https://docs.sablier.com/concepts/protocol/stream-types#lockup-tranched
-    /// @param asset The address of the ERC-20 token to be streamed
-    /// @param totalAmount The total amount of ERC-20 tokens to be streamed
-    /// @param startTime The timestamp when the stream takes effect
-    /// @param recipient The address receiving the ERC-20 tokens
-    /// @param numberOfTranches The number of tranches paid by the stream
-    /// @param recurrence The recurrence of each tranche
-    function createTranchedStream(
-        IERC20 asset,
-        uint128 totalAmount,
-        uint40 startTime,
-        address recipient,
-        uint128 numberOfTranches,
-        Types.Recurrence recurrence
-    )
-        external
-        returns (uint256 streamId);
-
     /// @notice Updates the fee charged by the broker
     ///
     /// Notes:
@@ -120,20 +86,4 @@ interface IStreamManager {
     ///
     /// @param newBrokerFee The new broker fee
     function updateStreamBrokerFee(UD60x18 newBrokerFee) external;
-
-    /// @notice See the documentation in {ISablierV2Lockup-withdrawMax}
-    /// Notes:
-    /// - `streamType` parameter has been added to get the correct {ISablierV2Lockup} implementation
-    function withdrawMaxStream(
-        Types.Method streamType,
-        uint256 streamId,
-        address to
-    )
-        external
-        returns (uint128 withdrawnAmount);
-
-    /// @notice See the documentation in {ISablierV2Lockup-cancel}
-    /// Notes:
-    /// - `streamType` parameter has been added to get the correct {ISablierV2Lockup} implementation
-    function cancelStream(Types.Method streamType, uint256 streamId) external;
 }


### PR DESCRIPTION
### Changelog:
- Makes Sablier-related methods internal to avoid bypassing the `PaymentModule` interface; A user could directly call the (old) `createLinearStream` method, bypassing the public `createRequest` call that must be performed to create a stream-based request;