### PR TITLE
chore: emit in create compensation plan

### DIFF
--- a/src/modules/compensation-module/CompensationModule.sol
+++ b/src/modules/compensation-module/CompensationModule.sol
@@ -228,6 +228,9 @@ contract CompensationModule is ICompensationModule, FlowStreamManager, UUPSUpgra
 
         // Checks, Effects, Interactions: create the compensation plan
         (compensationPlanId, streamId) = _createCompensationPlan(recipient, component);
+
+        // Log the compensation plan creation
+        emit CompensationPlanCreated(compensationPlanId, recipient, streamId);
     }
 
     /// @inheritdoc ICompensationModule
@@ -425,8 +428,5 @@ contract CompensationModule is ICompensationModule, FlowStreamManager, UUPSUpgra
         unchecked {
             $.nextCompensationPlanId++;
         }
-
-        // Log the compensation plan creation
-        emit CompensationPlanCreated(compensationPlanId, recipient, streamId);
     }
 }


### PR DESCRIPTION
### Changelog:
- Moves the `CompensationPlanCreated` emit in the main `createCompensationPlan` method;