### PR TITLE
fix: wrong Sablier Lockup deployment address on Base Sepolia

### DIFF
--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -73,7 +73,7 @@ contract BaseScript is Script {
         // Testnets
 
         // Base Sepolia deployment
-        sablierLockupMap[84_532] = 0x98A2bec0F94526Abef78893DE0B5756B921D08d5;
+        sablierLockupMap[84_532] = 0x5C51EA827Bfa65f7c9AF699e19Ec9fB12A2D40E2;
 
         // Ethereum Sepolia deployment
         sablierLockupMap[11_155_111] = 0x6b0307b4338f2963A62106028E3B074C2c0510DA;


### PR DESCRIPTION
### Changelog: 
- Updates the address of the Sablier Lockup deployment on Base Sepolia to the correct one in the `Base` script;